### PR TITLE
CEDA Specific release for integration with CEDA OpenID Provider.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     install_requires = [
         "Paste>=1.4", "nose>=0.9.2", "PasteDeploy>=1.1", "Beaker>=1.1",
         "PasteScript>=1.1", "python-openid>=2.1.1", 
-        "elementtree>=1.2,<=1.3", "decorator>=2.1.0",
+#        "elementtree>=1.2,<=1.3",
+        "decorator>=2.1.0",
         "WebOb>=0.9.3",
     ],
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ long_description = (
     '========\n'
 )
 
-version = '0.4.5'
+version = '0.4.6-ceda'
 
 setup(
     name="AuthKit",


### PR DESCRIPTION
Made changes to allow custom setting of POST field name for Relying Party UI and also to force sending keyword args by GET method instead of POST in redirect to Provider.  This is to allow consistent behaviour with ESGF OpenID Relying Party for use of the two in a scriptable sign in flow.
